### PR TITLE
revert to upstream url to install hiera-etcd

### DIFF
--- a/puppetmaster/install.pp
+++ b/puppetmaster/install.pp
@@ -108,8 +108,7 @@ class { 'puppetdb::master::config':
 
 # Install hiera-etcd backend.
 #
-# $url = 'https://raw.githubusercontent.com/garethr/hiera-etcd/master/lib/hiera/backend/etcd_backend.rb'
-$url = 'https://raw.githubusercontent.com/jumanjiman/hiera-etcd/json/lib/hiera/backend/etcd_backend.rb'
+$url = 'https://raw.githubusercontent.com/garethr/hiera-etcd/master/lib/hiera/backend/etcd_backend.rb'
 exec { 'install hiera-etcd':
   command => "/usr/bin/curl -sS -L -O $url",
   cwd     => '/usr/lib/ruby/site_ruby/1.8/hiera/backend',


### PR DESCRIPTION
https://github.com/jumanjihouse/docker-puppet/pull/10 switched
the url to my fork of hiera-etcd.

https://github.com/garethr/hiera-etcd/pull/6 has been merged, so
it's better imho to use the upstream url to ensure we always have
the latest version of hiera-etcd.
