### PR TITLE
avoid pathological root priv in autostager

### DIFF
--- a/autostager/Dockerfile
+++ b/autostager/Dockerfile
@@ -17,4 +17,4 @@ RUN mkdir -p /opt/puppet/environments && \
 VOLUME ["/opt/puppet/environments"]
 
 USER puppet
-CMD autostager
+ENTRYPOINT ["autostager"]


### PR DESCRIPTION
For some weird reason on docker 1.7.1, the CMD form causes
autostager to be forked from root.

The ENTRYPOINT form behaves as expected.
i.e., autostager runs unprivileged.