### PR TITLE
puppetmaster: avoid "413 Request Entity Too Large" on windows agent

### DIFF
--- a/puppetmaster/etc/nginx.conf
+++ b/puppetmaster/etc/nginx.conf
@@ -16,6 +16,11 @@ http {
     include      /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    # Disable this check.
+    # Avoids error seen on windows hosts:
+    #   413 Request Entity Too Large
+    client_max_body_size 0;
+
     # README!!
     #
     # Use https://securityheaders.io/?q=http%3A%2F%2Flogin.ISE.com


### PR DESCRIPTION
On some windows agents, we see...

    Error: Could not send report: Error 413 on SERVER: <html>
    <head><title>413 Request Entity Too Large</title></head>
    <body bgcolor="white">
    <center><h1>413 Request Entity Too Large</h1></center>
    <hr><center>nginx</center>
    </body>
    </html>

This commit disables the check and resolves the above error for us.